### PR TITLE
gestion des pierres

### DIFF
--- a/include/Cite.hpp
+++ b/include/Cite.hpp
@@ -19,7 +19,7 @@ public:
     Cite(const Tuile* tuileDeDepart);
     ~Cite() = default;
 
-
+    std::vector<const Tuile*>getTuiles(){return  tuiles;}
     virtual bool placerTuileFromHexRef(Hexagone* hex) = 0; // return true si la Tuile a été placé
     void addTuile(const Tuile* t);
 

--- a/include/Jeu.hpp
+++ b/include/Jeu.hpp
@@ -69,7 +69,7 @@ class Jeu {
     
     Pioche pioche;  
     std::vector<Tuile*> chantier; 
-
+    int nombreTuilesChantier; 
     int niveauDeDifficulte; 
 
 

--- a/include/Joueur.hpp
+++ b/include/Joueur.hpp
@@ -14,6 +14,7 @@ class Joueur{
     uint32_t getNbPierres() const { return nbPierres; }
     void setNbPierre(uint32_t nouveau_nb_pierre){nbPierres=nouveau_nb_pierre; }
     Cite* getCite() const { return cite; }
+    void MaJPierres(); 
 
 
     protected:

--- a/include/Tuile.hpp
+++ b/include/Tuile.hpp
@@ -101,6 +101,8 @@ public:
     int getNiveau()const;
 
     std::array<int, 8> getVoisinsList() const;
+
+    int gainPierre()const; 
 protected:
     Type type;
     Couleur couleur;

--- a/src/Cite.cpp
+++ b/src/Cite.cpp
@@ -550,6 +550,8 @@ bool CiteJoueur::placerTuileFromHexRef(Hexagone *hex)
                 hex2Fan->setVoisins(nullptr);
 
             hexFantome->setVoisins(nullptr);
+            
+            
         }
     }
 
@@ -907,12 +909,7 @@ uint32_t CiteIllu::compterPoints( int niveau_difficulte) const {
             }
         }
     }
-    std::cout << "printing points : " << points_bleu*nb_place_bleue*1 << " . " <<
-                    points_jaune *nb_place_jaune*2 << " . " <<
-                    points_rouge *nb_place_rouge*2 <<" . " <<
-                    points_vert*nb_place_verte*3 <<" . " <<
-                    points_violet*nb_place_violet*2 << std::endl;
-    std::cout << "niveau de difficulté : " <<niveau_difficulte<<"\n"; 
+    
     uint32_t total =
           points_bleu   * nb_place_bleue   * 1
         + points_jaune  * nb_place_jaune   * 2
@@ -950,3 +947,4 @@ void Cite::updateHexSrcFromFan(Hexagone *src, Hexagone *fan)
         }
     }
 };
+

--- a/src/Jeu.cpp
+++ b/src/Jeu.cpp
@@ -57,7 +57,7 @@ void Jeu::EndGame(){
 
 
 // Constructeur créant les tuilesCité de la partie
-Jeu::Jeu(int nbJoueur): mode(nbJoueur == 1 ? ModeDeJeu::Solo : ModeDeJeu::Multi), niveauDeDifficulte(0) , pioche(*this) {
+Jeu::Jeu(int nbJoueur): mode(nbJoueur == 1 ? ModeDeJeu::Solo : ModeDeJeu::Multi), niveauDeDifficulte(0) , pioche(*this),nombreTuilesChantier(nbJoueur+2) {
 
 
   // Définition des différentes quantités d'hexagones dans chaque catégorie
@@ -193,17 +193,24 @@ void Jeu::Lancer() {
             tourIllu(static_cast<Illu*>(joueurs.back())); 
           }
         }
-
-        // Après que tous les joueurs aient joué, demander si +1 tour
-        char reponse;
-        std::cout << "\nVoulez-vous continuer la partie ? (o/n) : ";
-        std::cin >> reponse;
-        if (reponse != 'o' && reponse != 'O') {
-            fin = true;
-        }
+        // Si il n'y a qu'une tuile dans le chantier et que la pioche est vide --> fin de partie 
+        if(chantier.size()==1 && pioche.estVide()){
+          fin =true; 
+        }else{
+          // Après que tous les joueurs aient joué, demander si +1 tour
+          char reponse;
+          std::cout << "\nVoulez-vous continuer la partie ? (o/n) : ";
+          std::cin >> reponse;
+          if (reponse != 'o' && reponse != 'O') {
+              fin = true;
+          }
+      }
     }
+    std::cout<<"============== FIN DE PARTIE =====================\n";
+    std::cout<<"AFFICHAGE DES SCORES \n";  
     for (auto& j : joueurs) {
-        std::cout << j->getCite()->compterPoints(niveauDeDifficulte) << std::endl;
+      std::cout<<j->getNom()<<" : "; 
+      std::cout << j->getCite()->compterPoints(niveauDeDifficulte) <<" points"<<std::endl;
     }
 }
 
@@ -250,7 +257,7 @@ void Jeu::tourJoueur(Joueur* joueur) {
     cin.ignore();
 
   // --- Affichage chantier global partagé ---
-    if (chantier.empty()) {            
+    if (chantier.size()<=1) {            
       mettreAJourChantier();         
     }
     afficherChantier();                        // Affiche le chantier actuel
@@ -284,6 +291,9 @@ void Jeu::tourJoueur(Joueur* joueur) {
     std::cout << "\nTuile correctement placée :\n";
     joueur->getCite()->afficher();
 
+    // Ajout du nombre de pierre en fonction de la tuile placée 
+    joueur->MaJPierres(); 
+
 }
 void Jeu::tourIllu(Illu* illu){
   // ===== Infos début du tour =====
@@ -311,7 +321,7 @@ void Jeu::tourIllu(Illu* illu){
 //piocher 
 // === Met à jour le chantier global si moins de 5 tuiles ===
 void Jeu::mettreAJourChantier() {
-    while (chantier.size() < 5 && !pioche.estVide()) {
+    while (chantier.size() < nombreTuilesChantier && !pioche.estVide()) {
         chantier.push_back(pioche.piocher());
     }
 }

--- a/src/Jeu.cpp
+++ b/src/Jeu.cpp
@@ -152,7 +152,7 @@ void Jeu::Initialiser(const int& nbJoueur) {
 
     tuilesDepart.push_back(new TuileDepart(*hexs[n], *hexs[n+1], *hexs[n+2], *hexs[n+3]));
     // Création du joueur
-    joueurs.push_back(new Joueur(name.c_str(), 2, tuilesDepart[tuilesDepart.size() - 1]));   
+    joueurs.push_back(new Joueur(name.c_str(), i+1, tuilesDepart[tuilesDepart.size() - 1]));   
   }
 
   // creation du joueur illustre architecte pour la partie en mode solo

--- a/src/Joueur.cpp
+++ b/src/Joueur.cpp
@@ -1,5 +1,8 @@
 #include "Joueur.hpp"
 #include "Exception.hpp"
+#include "Tuile.hpp"
+#include <iostream>
+
 
 Joueur::Joueur(const char* nom, uint32_t nbPierres, const Tuile* tuileDeDepart) :
     nom{nom}, nbPierres{nbPierres}, cite{nullptr} {
@@ -16,3 +19,21 @@ Illu::Illu(uint32_t nb_p, const Tuile* tdD)
     cite = new CiteIllu(tdD);
 }
 
+void Joueur::MaJPierres(){
+    int nlles_pierres = 0; 
+    if(!getCite()->getTuiles().empty()){
+        const Tuile*  tuile = getCite()->getTuiles().back(); 
+        auto hexagones = tuile->get_hexagones(); 
+        for(auto& hex : hexagones ){
+            nlles_pierres += hex->gainPierre(); 
+        }
+        if(nlles_pierres!=0){
+            setNbPierre(getNbPierres()+nlles_pierres); 
+            std::cout<<"Vous avez gagnez "<<nlles_pierres<<" pierres. \n"; 
+        }
+    
+    }
+}; 
+    
+    
+    

--- a/src/Tuile.cpp
+++ b/src/Tuile.cpp
@@ -259,3 +259,11 @@ int Hexagone::getNiveau()const{
         }
     return niveau; 
 };
+
+
+int Hexagone::gainPierre()const{
+    if(this->getVoisinsBOT()!=nullptr){
+        if(this->getVoisinsBOT()->getType()==Type::Carriere)return 1;
+        else return 0; 
+    }else return 0; 
+}


### PR DESCRIPTION
Maintenant la gestion des pierres est bonne. Le joueur gagne une pierre à chaque fois qu'il recouvre une carrière. 
J'ai aussi modifier pour le chantier le nombre de tuiles (il varie en fonction du nombre de joueurs), et aussi le fait qu'on le mette à jour quand il reste une tuile et pas quand il est vide (pour qu'on soit raccord sur les règles). Et j'ai rajouté une condition pour que la partie se termine au moment ou il n'y plus qu'une tuile dans le chantier et que la pioche est vide. 